### PR TITLE
Fix method signature for Context Menu Show/Hide Item

### DIFF
--- a/Restrainite/Patches/ShowOrHideContextMenuItems.cs
+++ b/Restrainite/Patches/ShowOrHideContextMenuItems.cs
@@ -62,9 +62,9 @@ internal static class ShowOrHideContextMenuItems
     [HarmonyPatch(typeof(ContextMenu), "AddItem",
         [
             typeof(LocaleString), typeof(IAssetProvider<ITexture2D>), typeof(Uri), typeof(IAssetProvider<Sprite>),
-            typeof(colorX?)
+            typeof(colorX?), typeof(bool)
         ],
-        [ArgumentType.Ref, ArgumentType.Normal, ArgumentType.Normal, ArgumentType.Normal, ArgumentType.Ref])]
+        [ArgumentType.Ref, ArgumentType.Normal, ArgumentType.Normal, ArgumentType.Normal, ArgumentType.Ref, ArgumentType.Normal])]
     public static void ShowOrHideContextMenuItems_ContextMenuAddItem_Postfix(LocaleString label,
         ContextMenuItem __result)
     {

--- a/Restrainite/Restrainite.csproj
+++ b/Restrainite/Restrainite.csproj
@@ -43,7 +43,7 @@
     </PropertyGroup>
     <ItemGroup>
         <Reference Include="FrooxEngine.Store">
-            <HintPath>D:\SteamLibrary\steamapps\common\Resonite\Resonite_Data\Managed\FrooxEngine.Store.dll</HintPath>
+            <HintPath>$(ResonitePath)Resonite_Data\Managed\FrooxEngine.Store.dll</HintPath>
         </Reference>
         <Reference Include="SkyFrost.Base.Models">
             <HintPath>$(ResonitePath)Resonite_Data\Managed\SkyFrost.Base.Models.dll</HintPath>


### PR DESCRIPTION
This PR fixes the method signature of the ContextMenu.AddItem() due to changes in the latest Resonite update. The latest update added a new optional bool argument colorFromImage to the method.